### PR TITLE
Made the WinEvents handle public

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -147,7 +147,7 @@ impl Drop for EvtHandleWrapper {
 
 /// Entry point for querying the event log
 pub struct WinEvents {
-    handle: Option<EvtHandleWrapper>,
+    pub handle: Option<EvtHandleWrapper>,
 }
 
 impl WinEvents {


### PR DESCRIPTION
This is so the events can be modified using the winapi once they are queried.