### PR TITLE
allow for querying of all event in a given Path

### DIFF
--- a/src/query_list/query_item.rs
+++ b/src/query_list/query_item.rs
@@ -70,7 +70,10 @@ impl fmt::Display for QueryItem {
                 if let Some(ref conditions) = self.event_data_conditions {
                     parts.push(format!("*[EventData[{conditions}]]"))
                 }
-                write!(f, "{}", parts.join("\nand\n"))?;
+                match parts.is_empty() {
+                    true => write!(f, "*")?,
+                    false => write!(f, "{}", parts.join("\nand\n"))?,
+                }
                 write!(f, "\n</{}>", self.query_item_type)
             }
             None => write!(f, ""),


### PR DESCRIPTION
to query all the log from a path the XML select must contain : "*". But if a query item has no condition "" is written instead