### PR TITLE
fix computer query

### DIFF
--- a/src/query_list/event_filter/computer.rs
+++ b/src/query_list/event_filter/computer.rs
@@ -13,6 +13,6 @@ impl Computer {
 
 impl fmt::Display for Computer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "System[@Computer = '{}']", self.name)
+        write!(f, "Computer = '{}'", self.name)
     }
 }


### PR DESCRIPTION
querying for computer specific log generted the wrong xml query, nesting two time the "System[something]" resulting in the wrong query. it now found the correct number of logs.