### PR TITLE
Fix EvtRender buffer size calculations and null terminator handling

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -319,13 +319,14 @@ impl Iterator for WinEventsIntoIterator {
                         ) == 0
                             && GetLastError() == 122
                     } {
-                        let mut buf: Vec<u16> = vec![0; buffer_used as usize];
+                        let buf_len = buffer_used as usize / std::mem::size_of::<u16>();
+                        let mut buf: Vec<u16> = vec![0; buf_len];
                         match unsafe {
                             render(
                                 null_mut(),
                                 handle.0 as _,
                                 1,
-                                buf.len() as _,
+                                (buf.len() * std::mem::size_of::<u16>()) as _,
                                 buf.as_mut_ptr() as _,
                                 &mut buffer_used,
                                 &mut property_count,
@@ -333,7 +334,14 @@ impl Iterator for WinEventsIntoIterator {
                         } {
                             0 => None,
                             _ => {
-                                let s = OsString::from_wide(&buf[..]).to_string_lossy().to_string();
+                                if buf.is_empty() {
+                                    return Some(Event(String::new()));
+                                }
+                                debug_assert_eq!(buf.last(), Some(&0u16));
+                                let nul_trimmed = buf.len() - 1;
+                                let s = OsString::from_wide(&buf[..nul_trimmed])
+                                    .to_string_lossy()
+                                    .to_string();
                                 Some(Event(s))
                             }
                         }


### PR DESCRIPTION
The EvtRender API reports BufferUsed in bytes, but the old code had two bugs that partially cancelled each other out:

buffer_used was used directly as the element count for a Vec<u16>, allocating a buffer 2x larger than needed.
buf.len() (element count) was passed as BufferSize, which expects bytes.

The net effect was that EvtRender received the correct byte size by accident, but the oversized buffer produced trailing null characters in every rendered event string.

This change:

Correctly converts buffer_used from bytes to u16 element count for allocation
Passes buf.len() * size_of::<u16>() as BufferSize (bytes, per the API contract)
Strips the null terminator at the u16 buffer level